### PR TITLE
Fix redis secret error

### DIFF
--- a/templates/redis-secret.yaml
+++ b/templates/redis-secret.yaml
@@ -7,5 +7,5 @@ metadata:
     {{- include "rctf.labels" . | nindent 4 }}
 type: Opaque
 data:
-  password: {{ required "redis.password is required" .Values.redis.password | b64enc | quote }}
+  redis-password: {{ required "redis.password is required" .Values.redis.password | b64enc | quote }}
 {{- end }}


### PR DESCRIPTION
The name of the redis secret needs to be `redis-password`

```
Error: Couldn't find key redis-password in Secret rctf-redis
```